### PR TITLE
Completed: Brock Boland

### DIFF
--- a/ChangingBackground.xcodeproj/project.pbxproj
+++ b/ChangingBackground.xcodeproj/project.pbxproj
@@ -153,10 +153,7 @@
 				465F1FF21960FF2400F25C97 /* BackgroundImageViewController.m */,
 				001809DB171C644A002D3E93 /* FirstViewController */,
 				001809E2171C650E002D3E93 /* SecondViewController */,
-				465F1FEE1960FCC700F25C97 /* BackgroundNavigationViewController.h */,
-				465F1FEF1960FCC700F25C97 /* BackgroundNavigationViewController.m */,
-				465F1FF419610A1900F25C97 /* PushAnimator.h */,
-				465F1FF519610A1900F25C97 /* PushAnimator.m */,
+				465F1FF719610E5A00F25C97 /* Nav Controller */,
 			);
 			name = ViewControllers;
 			sourceTree = "<group>";
@@ -180,6 +177,17 @@
 				001809EA171C6764002D3E93 /* green@2x.png */,
 			);
 			name = BackgroundImages;
+			sourceTree = "<group>";
+		};
+		465F1FF719610E5A00F25C97 /* Nav Controller */ = {
+			isa = PBXGroup;
+			children = (
+				465F1FEE1960FCC700F25C97 /* BackgroundNavigationViewController.h */,
+				465F1FEF1960FCC700F25C97 /* BackgroundNavigationViewController.m */,
+				465F1FF419610A1900F25C97 /* PushAnimator.h */,
+				465F1FF519610A1900F25C97 /* PushAnimator.m */,
+			);
+			name = "Nav Controller";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/ChangingBackground.xcodeproj/project.pbxproj
+++ b/ChangingBackground.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		001809EE171C6764002D3E93 /* green@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 001809EA171C6764002D3E93 /* green@2x.png */; };
 		465F1FF01960FCC700F25C97 /* BackgroundNavigationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 465F1FEF1960FCC700F25C97 /* BackgroundNavigationViewController.m */; };
 		465F1FF31960FF2400F25C97 /* BackgroundImageViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 465F1FF21960FF2400F25C97 /* BackgroundImageViewController.m */; };
+		465F1FF619610A1900F25C97 /* PushAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = 465F1FF519610A1900F25C97 /* PushAnimator.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -56,6 +57,8 @@
 		465F1FEF1960FCC700F25C97 /* BackgroundNavigationViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BackgroundNavigationViewController.m; sourceTree = "<group>"; };
 		465F1FF11960FF2400F25C97 /* BackgroundImageViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BackgroundImageViewController.h; sourceTree = "<group>"; };
 		465F1FF21960FF2400F25C97 /* BackgroundImageViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BackgroundImageViewController.m; sourceTree = "<group>"; };
+		465F1FF419610A1900F25C97 /* PushAnimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PushAnimator.h; sourceTree = "<group>"; };
+		465F1FF519610A1900F25C97 /* PushAnimator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PushAnimator.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -152,6 +155,8 @@
 				001809E2171C650E002D3E93 /* SecondViewController */,
 				465F1FEE1960FCC700F25C97 /* BackgroundNavigationViewController.h */,
 				465F1FEF1960FCC700F25C97 /* BackgroundNavigationViewController.m */,
+				465F1FF419610A1900F25C97 /* PushAnimator.h */,
+				465F1FF519610A1900F25C97 /* PushAnimator.m */,
 			);
 			name = ViewControllers;
 			sourceTree = "<group>";
@@ -248,6 +253,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				465F1FF619610A1900F25C97 /* PushAnimator.m in Sources */,
 				465F1FF01960FCC700F25C97 /* BackgroundNavigationViewController.m in Sources */,
 				001809C5171C637E002D3E93 /* main.m in Sources */,
 				465F1FF31960FF2400F25C97 /* BackgroundImageViewController.m in Sources */,

--- a/ChangingBackground.xcodeproj/project.pbxproj
+++ b/ChangingBackground.xcodeproj/project.pbxproj
@@ -24,7 +24,8 @@
 		001809EC171C6764002D3E93 /* blue@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 001809E8171C6764002D3E93 /* blue@2x.png */; };
 		001809ED171C6764002D3E93 /* green.png in Resources */ = {isa = PBXBuildFile; fileRef = 001809E9171C6764002D3E93 /* green.png */; };
 		001809EE171C6764002D3E93 /* green@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 001809EA171C6764002D3E93 /* green@2x.png */; };
-		465F1FEA1960F7C300F25C97 /* BackgroundImageViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 465F1FE91960F7C300F25C97 /* BackgroundImageViewController.m */; };
+		465F1FF01960FCC700F25C97 /* BackgroundNavigationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 465F1FEF1960FCC700F25C97 /* BackgroundNavigationViewController.m */; };
+		465F1FF31960FF2400F25C97 /* BackgroundImageViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 465F1FF21960FF2400F25C97 /* BackgroundImageViewController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -51,8 +52,10 @@
 		001809E8171C6764002D3E93 /* blue@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "blue@2x.png"; sourceTree = "<group>"; };
 		001809E9171C6764002D3E93 /* green.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = green.png; sourceTree = "<group>"; };
 		001809EA171C6764002D3E93 /* green@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "green@2x.png"; sourceTree = "<group>"; };
-		465F1FE81960F7C300F25C97 /* BackgroundImageViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BackgroundImageViewController.h; sourceTree = "<group>"; };
-		465F1FE91960F7C300F25C97 /* BackgroundImageViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BackgroundImageViewController.m; sourceTree = "<group>"; };
+		465F1FEE1960FCC700F25C97 /* BackgroundNavigationViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BackgroundNavigationViewController.h; sourceTree = "<group>"; };
+		465F1FEF1960FCC700F25C97 /* BackgroundNavigationViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BackgroundNavigationViewController.m; sourceTree = "<group>"; };
+		465F1FF11960FF2400F25C97 /* BackgroundImageViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BackgroundImageViewController.h; sourceTree = "<group>"; };
+		465F1FF21960FF2400F25C97 /* BackgroundImageViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BackgroundImageViewController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -143,10 +146,12 @@
 		001809DC171C6453002D3E93 /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
+				465F1FF11960FF2400F25C97 /* BackgroundImageViewController.h */,
+				465F1FF21960FF2400F25C97 /* BackgroundImageViewController.m */,
 				001809DB171C644A002D3E93 /* FirstViewController */,
 				001809E2171C650E002D3E93 /* SecondViewController */,
-				465F1FE81960F7C300F25C97 /* BackgroundImageViewController.h */,
-				465F1FE91960F7C300F25C97 /* BackgroundImageViewController.m */,
+				465F1FEE1960FCC700F25C97 /* BackgroundNavigationViewController.h */,
+				465F1FEF1960FCC700F25C97 /* BackgroundNavigationViewController.m */,
 			);
 			name = ViewControllers;
 			sourceTree = "<group>";
@@ -243,9 +248,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				465F1FF01960FCC700F25C97 /* BackgroundNavigationViewController.m in Sources */,
 				001809C5171C637E002D3E93 /* main.m in Sources */,
+				465F1FF31960FF2400F25C97 /* BackgroundImageViewController.m in Sources */,
 				001809C9171C637E002D3E93 /* AppDelegate.m in Sources */,
-				465F1FEA1960F7C300F25C97 /* BackgroundImageViewController.m in Sources */,
 				001809D9171C6448002D3E93 /* FirstViewController.m in Sources */,
 				001809E0171C64E4002D3E93 /* SecondViewController.m in Sources */,
 			);

--- a/ChangingBackground.xcodeproj/project.pbxproj
+++ b/ChangingBackground.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		001809EC171C6764002D3E93 /* blue@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 001809E8171C6764002D3E93 /* blue@2x.png */; };
 		001809ED171C6764002D3E93 /* green.png in Resources */ = {isa = PBXBuildFile; fileRef = 001809E9171C6764002D3E93 /* green.png */; };
 		001809EE171C6764002D3E93 /* green@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 001809EA171C6764002D3E93 /* green@2x.png */; };
+		465F1FEA1960F7C300F25C97 /* BackgroundImageViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 465F1FE91960F7C300F25C97 /* BackgroundImageViewController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -50,6 +51,8 @@
 		001809E8171C6764002D3E93 /* blue@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "blue@2x.png"; sourceTree = "<group>"; };
 		001809E9171C6764002D3E93 /* green.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = green.png; sourceTree = "<group>"; };
 		001809EA171C6764002D3E93 /* green@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "green@2x.png"; sourceTree = "<group>"; };
+		465F1FE81960F7C300F25C97 /* BackgroundImageViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BackgroundImageViewController.h; sourceTree = "<group>"; };
+		465F1FE91960F7C300F25C97 /* BackgroundImageViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BackgroundImageViewController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -142,6 +145,8 @@
 			children = (
 				001809DB171C644A002D3E93 /* FirstViewController */,
 				001809E2171C650E002D3E93 /* SecondViewController */,
+				465F1FE81960F7C300F25C97 /* BackgroundImageViewController.h */,
+				465F1FE91960F7C300F25C97 /* BackgroundImageViewController.m */,
 			);
 			name = ViewControllers;
 			sourceTree = "<group>";
@@ -240,6 +245,7 @@
 			files = (
 				001809C5171C637E002D3E93 /* main.m in Sources */,
 				001809C9171C637E002D3E93 /* AppDelegate.m in Sources */,
+				465F1FEA1960F7C300F25C97 /* BackgroundImageViewController.m in Sources */,
 				001809D9171C6448002D3E93 /* FirstViewController.m in Sources */,
 				001809E0171C64E4002D3E93 /* SecondViewController.m in Sources */,
 			);
@@ -356,6 +362,7 @@
 				001809D4171C637E002D3E93 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/ChangingBackground/AppDelegate.m
+++ b/ChangingBackground/AppDelegate.m
@@ -28,7 +28,7 @@
     [navigationController setNavigationBarHidden:YES];
 
     window.rootViewController = navigationController;
-    
+
     return YES;
 }
 

--- a/ChangingBackground/AppDelegate.m
+++ b/ChangingBackground/AppDelegate.m
@@ -8,6 +8,7 @@
 
 #import "AppDelegate.h"
 #import "FirstViewController.h"
+#import "BackgroundNavigationViewController.h"
 
 @interface AppDelegate () {
     UIWindow *window;
@@ -22,7 +23,8 @@
     [window makeKeyAndVisible];
     
     FirstViewController *firstViewController = FirstViewController.new;
-    UINavigationController *navigationController = [UINavigationController.alloc initWithRootViewController:firstViewController];
+
+    BackgroundNavigationViewController *navigationController = [BackgroundNavigationViewController.alloc initWithRootViewController:firstViewController];
     [navigationController setNavigationBarHidden:YES];
 
     window.rootViewController = navigationController;

--- a/ChangingBackground/BackgroundImageViewController.h
+++ b/ChangingBackground/BackgroundImageViewController.h
@@ -10,7 +10,11 @@
 
 @interface BackgroundImageViewController : UIViewController
 
-/// Image to shown behind the contents of the view controller
-@property (strong, nonatomic) UIImage *backgroundImage;
+/**
+ * Get the image to display behind the view controller
+ *
+ * @return Image to use in the background
+ */
+-(UIImage*)backgroundImage;
 
 @end

--- a/ChangingBackground/BackgroundImageViewController.h
+++ b/ChangingBackground/BackgroundImageViewController.h
@@ -1,0 +1,16 @@
+//
+//  BackgroundImageViewController.h
+//  ChangingBackground
+//
+//  Created by Brock Boland on 6/29/14.
+//  Copyright (c) 2014 Ora Interactive. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface BackgroundImageViewController : UIViewController
+
+/// Image to shown behind the contents of the view controller
+@property (strong, nonatomic) UIImage *backgroundImage;
+
+@end

--- a/ChangingBackground/BackgroundImageViewController.m
+++ b/ChangingBackground/BackgroundImageViewController.m
@@ -1,0 +1,45 @@
+//
+//  BackgroundImageViewController.m
+//  ChangingBackground
+//
+//  Created by Brock Boland on 6/29/14.
+//  Copyright (c) 2014 Ora Interactive. All rights reserved.
+//
+
+#import "BackgroundImageViewController.h"
+
+@interface BackgroundImageViewController ()
+/// View for the background image
+@property (strong, nonatomic) UIImageView *backgroundImageView;
+
+@end
+
+@implementation BackgroundImageViewController
+
+-(id)init {
+  self = [super init];
+  if (self) {
+    // Add the background image view and send it behind other views
+    [self.view addSubview:self.backgroundImageView];
+    [self.view sendSubviewToBack:self.backgroundImageView];
+  }
+  return self;
+}
+
+
+// Lazy-init the background view
+-(UIImageView *)backgroundImageView {
+  if (!_backgroundImageView) {
+    _backgroundImageView = [[UIImageView alloc] initWithFrame:self.view.frame];
+  }
+  return _backgroundImageView;
+}
+
+// Override the setter for the backgroundImage property, to update the
+// background image when the image is changed
+-(void)setBackgroundImage:(UIImage *)backgroundImage {
+  _backgroundImage = backgroundImage;
+  self.backgroundImageView.image = backgroundImage;
+}
+
+@end

--- a/ChangingBackground/BackgroundImageViewController.m
+++ b/ChangingBackground/BackgroundImageViewController.m
@@ -8,38 +8,11 @@
 
 #import "BackgroundImageViewController.h"
 
-@interface BackgroundImageViewController ()
-/// View for the background image
-@property (strong, nonatomic) UIImageView *backgroundImageView;
-
-@end
-
 @implementation BackgroundImageViewController
 
--(id)init {
-  self = [super init];
-  if (self) {
-    // Add the background image view and send it behind other views
-    [self.view addSubview:self.backgroundImageView];
-    [self.view sendSubviewToBack:self.backgroundImageView];
-  }
-  return self;
-}
-
-
-// Lazy-init the background view
--(UIImageView *)backgroundImageView {
-  if (!_backgroundImageView) {
-    _backgroundImageView = [[UIImageView alloc] initWithFrame:self.view.frame];
-  }
-  return _backgroundImageView;
-}
-
-// Override the setter for the backgroundImage property, to update the
-// background image when the image is changed
--(void)setBackgroundImage:(UIImage *)backgroundImage {
-  _backgroundImage = backgroundImage;
-  self.backgroundImageView.image = backgroundImage;
+-(UIImage *)backgroundImage {
+  // This is overridden in child classes
+  return nil;
 }
 
 @end

--- a/ChangingBackground/BackgroundNavigationViewController.h
+++ b/ChangingBackground/BackgroundNavigationViewController.h
@@ -1,0 +1,16 @@
+//
+//  BackgroundNavigationViewController.h
+//  ChangingBackground
+//
+//  Created by Brock Boland on 6/29/14.
+//  Copyright (c) 2014 Ora Interactive. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface BackgroundNavigationViewController : UINavigationController <UINavigationControllerDelegate>
+
+/// Background image view
+@property (strong, nonatomic) UIImageView *backgroundImage;
+
+@end

--- a/ChangingBackground/BackgroundNavigationViewController.m
+++ b/ChangingBackground/BackgroundNavigationViewController.m
@@ -1,0 +1,58 @@
+//
+//  BackgroundNavigationViewController.m
+//  ChangingBackground
+//
+//  Created by Brock Boland on 6/29/14.
+//  Copyright (c) 2014 Ora Interactive. All rights reserved.
+//
+
+#import "BackgroundNavigationViewController.h"
+#import "BackgroundImageViewController.h"
+
+@interface BackgroundNavigationViewController ()
+/// The view for the background image
+@property (strong, nonatomic) UIImageView *backgroundImageView;
+
+@end
+
+@implementation BackgroundNavigationViewController
+
+-(id)initWithRootViewController:(UIViewController *)rootViewController {
+  self = [super initWithRootViewController:rootViewController];
+  if (self) {
+    // I'll handle this myself
+    self.delegate = self;
+
+    // Add a background image
+    self.backgroundImageView = [[UIImageView alloc] initWithFrame:self.view.frame];
+    [self.view addSubview:self.backgroundImageView];
+    [self.view sendSubviewToBack:self.backgroundImageView];
+  }
+  return self;
+}
+
+
+-(void)navigationController:(UINavigationController *)navigationController willShowViewController:(UIViewController *)viewController animated:(BOOL)animated {
+  // Make sure that the background image will be visible behind the view controller
+  viewController.view.backgroundColor = [UIColor clearColor];
+
+  // If the background image is not set already, set it based on the view
+  // controller that is about to show. This ensures that the first view controller
+  // shown will have a background image.
+  if (!self.backgroundImageView.image && [viewController isKindOfClass:[BackgroundImageViewController class]]) {
+    BackgroundImageViewController *bgVC = (BackgroundImageViewController*)viewController;
+    self.backgroundImageView.image = bgVC.backgroundImage;
+  }
+}
+
+
+// When a new view controller is shown, fade to that view controller's background image
+-(void)navigationController:(UINavigationController *)navigationController didShowViewController:(UIViewController *)viewController animated:(BOOL)animated {
+  if ([viewController isKindOfClass:[BackgroundImageViewController class]]) {
+    // TODO fade
+    BackgroundImageViewController *bgVC = (BackgroundImageViewController*)viewController;
+    self.backgroundImageView.image = bgVC.backgroundImage;
+  }
+}
+
+@end

--- a/ChangingBackground/BackgroundNavigationViewController.m
+++ b/ChangingBackground/BackgroundNavigationViewController.m
@@ -24,7 +24,7 @@
 -(id)initWithRootViewController:(UIViewController *)rootViewController {
   self = [super initWithRootViewController:rootViewController];
   if (self) {
-    // I'll handle this myself
+    // Handle transitions
     self.delegate = self;
 
     // Add a background image view
@@ -61,16 +61,17 @@
     BackgroundImageViewController *bgVC = (BackgroundImageViewController*)viewController;
 
     // Move the "fading" background image view in front of the main one, set
-    // it's background image, and make it clear for now
+    // its background image, and hide it for the moment.
     self.fadingBackgroundImageView.image = bgVC.backgroundImage;
     self.fadingBackgroundImageView.alpha = 0.0;
     [self.view sendSubviewToBack:self.mainBackgroundImageView];
 
     [UIView animateWithDuration:1.0 animations:^{
-      // Fade in the new background
+      // Fade in the new background by changing the alpha
       self.fadingBackgroundImageView.alpha = 1.0;
     } completion:^(BOOL finished) {
-      // Once the fade is complete, set the "main" background to use the new image
+      // Once the fade is complete, set the "main" background to use the new
+      // image, and move it in front of the fading view.
       self.mainBackgroundImageView.image = self.fadingBackgroundImageView.image;
       [self.view sendSubviewToBack:self.fadingBackgroundImageView];
     }];

--- a/ChangingBackground/BackgroundNavigationViewController.m
+++ b/ChangingBackground/BackgroundNavigationViewController.m
@@ -8,6 +8,7 @@
 
 #import "BackgroundNavigationViewController.h"
 #import "BackgroundImageViewController.h"
+#import "PushAnimator.h"
 
 @interface BackgroundNavigationViewController ()
 /// The view for the background image
@@ -16,6 +17,7 @@
 @property (strong, nonatomic) UIImageView *fadingBackgroundImageView;
 
 @end
+
 
 @implementation BackgroundNavigationViewController
 
@@ -74,5 +76,22 @@
     }];
   }
 }
+
+
+// Animation for the view transition
+-(id<UIViewControllerAnimatedTransitioning>)navigationController:(UINavigationController *)navigationController
+                                 animationControllerForOperation:(UINavigationControllerOperation)operation
+                                              fromViewController:(UIViewController *)fromVC
+                                                toViewController:(UIViewController *)toVC {
+
+  PushAnimator *animator = [[PushAnimator alloc] init];
+
+  if (operation == UINavigationControllerOperationPop) {
+    // Popping a view off, so reverse the transition
+    animator.reverse = YES;
+  }
+  return animator;
+}
+
 
 @end

--- a/ChangingBackground/BackgroundNavigationViewController.m
+++ b/ChangingBackground/BackgroundNavigationViewController.m
@@ -11,7 +11,9 @@
 
 @interface BackgroundNavigationViewController ()
 /// The view for the background image
-@property (strong, nonatomic) UIImageView *backgroundImageView;
+@property (strong, nonatomic) UIImageView *mainBackgroundImageView;
+/// The view used as a placeholder for the NEW background image.
+@property (strong, nonatomic) UIImageView *fadingBackgroundImageView;
 
 @end
 
@@ -23,10 +25,15 @@
     // I'll handle this myself
     self.delegate = self;
 
-    // Add a background image
-    self.backgroundImageView = [[UIImageView alloc] initWithFrame:self.view.frame];
-    [self.view addSubview:self.backgroundImageView];
-    [self.view sendSubviewToBack:self.backgroundImageView];
+    // Add a background image view
+    self.mainBackgroundImageView = [[UIImageView alloc] initWithFrame:self.view.frame];
+    [self.view addSubview:self.mainBackgroundImageView];
+    [self.view sendSubviewToBack:self.mainBackgroundImageView];
+
+    // Add the other background image view, used for fading
+    self.fadingBackgroundImageView = [[UIImageView alloc] initWithFrame:self.view.frame];
+    [self.view addSubview:self.fadingBackgroundImageView];
+    [self.view sendSubviewToBack:self.fadingBackgroundImageView];
   }
   return self;
 }
@@ -39,9 +46,9 @@
   // If the background image is not set already, set it based on the view
   // controller that is about to show. This ensures that the first view controller
   // shown will have a background image.
-  if (!self.backgroundImageView.image && [viewController isKindOfClass:[BackgroundImageViewController class]]) {
+  if (!self.mainBackgroundImageView.image && [viewController isKindOfClass:[BackgroundImageViewController class]]) {
     BackgroundImageViewController *bgVC = (BackgroundImageViewController*)viewController;
-    self.backgroundImageView.image = bgVC.backgroundImage;
+    self.mainBackgroundImageView.image = bgVC.backgroundImage;
   }
 }
 
@@ -49,9 +56,22 @@
 // When a new view controller is shown, fade to that view controller's background image
 -(void)navigationController:(UINavigationController *)navigationController didShowViewController:(UIViewController *)viewController animated:(BOOL)animated {
   if ([viewController isKindOfClass:[BackgroundImageViewController class]]) {
-    // TODO fade
     BackgroundImageViewController *bgVC = (BackgroundImageViewController*)viewController;
-    self.backgroundImageView.image = bgVC.backgroundImage;
+
+    // Move the "fading" background image view in front of the main one, set
+    // it's background image, and make it clear for now
+    self.fadingBackgroundImageView.image = bgVC.backgroundImage;
+    self.fadingBackgroundImageView.alpha = 0.0;
+    [self.view sendSubviewToBack:self.mainBackgroundImageView];
+
+    [UIView animateWithDuration:1.0 animations:^{
+      // Fade in the new background
+      self.fadingBackgroundImageView.alpha = 1.0;
+    } completion:^(BOOL finished) {
+      // Once the fade is complete, set the "main" background to use the new image
+      self.mainBackgroundImageView.image = self.fadingBackgroundImageView.image;
+      [self.view sendSubviewToBack:self.fadingBackgroundImageView];
+    }];
   }
 }
 

--- a/ChangingBackground/FirstViewController.h
+++ b/ChangingBackground/FirstViewController.h
@@ -7,8 +7,9 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "BackgroundImageViewController.h"
 
-@interface FirstViewController : UIViewController
+@interface FirstViewController : BackgroundImageViewController
 
 - (IBAction)goForwardButtonPressed;
 

--- a/ChangingBackground/FirstViewController.m
+++ b/ChangingBackground/FirstViewController.m
@@ -15,14 +15,9 @@
 
 @implementation FirstViewController
 
--(id)init {
-  self = [super init];
-  if (self) {
-    self.backgroundImage = [UIImage imageNamed:@"blue"];
-  }
-  return self;
+-(UIImage *)backgroundImage {
+  return [UIImage imageNamed:@"blue"];
 }
-
 
 - (IBAction)goForwardButtonPressed {
     SecondViewController *secondViewController = SecondViewController.new;

--- a/ChangingBackground/FirstViewController.m
+++ b/ChangingBackground/FirstViewController.m
@@ -15,6 +15,15 @@
 
 @implementation FirstViewController
 
+-(id)init {
+  self = [super init];
+  if (self) {
+    self.backgroundImage = [UIImage imageNamed:@"blue"];
+  }
+  return self;
+}
+
+
 - (IBAction)goForwardButtonPressed {
     SecondViewController *secondViewController = SecondViewController.new;
     [self.navigationController pushViewController:secondViewController animated:YES];

--- a/ChangingBackground/FirstViewController.xib
+++ b/ChangingBackground/FirstViewController.xib
@@ -1,217 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="8.00">
-	<data>
-		<int key="IBDocument.SystemTarget">1552</int>
-		<string key="IBDocument.SystemVersion">12C3006</string>
-		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
-		<string key="IBDocument.AppKitVersion">1187.34</string>
-		<string key="IBDocument.HIToolboxVersion">625.00</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">2083</string>
-		</object>
-		<array key="IBDocument.IntegratedClassDependencies">
-			<string>IBProxyObject</string>
-			<string>IBUIButton</string>
-			<string>IBUILabel</string>
-			<string>IBUIView</string>
-		</array>
-		<array key="IBDocument.PluginDependencies">
-			<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-		</array>
-		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
-			<integer value="1" key="NS.object.0"/>
-		</object>
-		<array class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
-			<object class="IBProxyObject" id="372490531">
-				<string key="IBProxiedObjectIdentifier">IBFilesOwner</string>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-			<object class="IBProxyObject" id="975951072">
-				<string key="IBProxiedObjectIdentifier">IBFirstResponder</string>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-			<object class="IBUIView" id="191373211">
-				<nil key="NSNextResponder"/>
-				<int key="NSvFlags">274</int>
-				<array class="NSMutableArray" key="NSSubviews">
-					<object class="IBUILabel" id="706097280">
-						<reference key="NSNextResponder" ref="191373211"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{77, 115}, {166, 21}}</string>
-						<reference key="NSSuperview" ref="191373211"/>
-						<reference key="NSNextKeyView" ref="545115536"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="IBUIOpaque">NO</bool>
-						<bool key="IBUIClipsSubviews">YES</bool>
-						<int key="IBUIContentMode">7</int>
-						<bool key="IBUIUserInteractionEnabled">NO</bool>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<string key="IBUIText">Home View Controller</string>
-						<object class="NSColor" key="IBUITextColor">
-							<int key="NSColorSpace">1</int>
-							<bytes key="NSRGB">MCAwIDAAA</bytes>
-							<string key="IBUIColorCocoaTouchKeyPath">darkTextColor</string>
-						</object>
-						<nil key="IBUIHighlightedColor"/>
-						<int key="IBUIBaselineAdjustment">0</int>
-						<object class="IBUIFontDescription" key="IBUIFontDescription">
-							<int key="type">1</int>
-							<double key="pointSize">17</double>
-						</object>
-						<object class="NSFont" key="IBUIFont">
-							<string key="NSName">Helvetica</string>
-							<double key="NSSize">17</double>
-							<int key="NSfFlags">16</int>
-						</object>
-						<bool key="IBUIAdjustsFontSizeToFit">NO</bool>
-					</object>
-					<object class="IBUIButton" id="545115536">
-						<reference key="NSNextResponder" ref="191373211"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{102, 180}, {109, 44}}</string>
-						<reference key="NSSuperview" ref="191373211"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="IBUIOpaque">NO</bool>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<int key="IBUIContentHorizontalAlignment">0</int>
-						<int key="IBUIContentVerticalAlignment">0</int>
-						<int key="IBUIButtonType">1</int>
-						<string key="IBUINormalTitle">Go Forward</string>
-						<object class="NSColor" key="IBUIHighlightedTitleColor">
-							<int key="NSColorSpace">3</int>
-							<bytes key="NSWhite">MQA</bytes>
-						</object>
-						<object class="NSColor" key="IBUINormalTitleColor">
-							<int key="NSColorSpace">1</int>
-							<bytes key="NSRGB">MC4xOTYwNzg0MzQ2IDAuMzA5ODAzOTMyOSAwLjUyMTU2ODY1NgA</bytes>
-						</object>
-						<object class="NSColor" key="IBUINormalTitleShadowColor">
-							<int key="NSColorSpace">3</int>
-							<bytes key="NSWhite">MC41AA</bytes>
-						</object>
-						<object class="IBUIFontDescription" key="IBUIFontDescription">
-							<int key="type">2</int>
-							<double key="pointSize">15</double>
-						</object>
-						<object class="NSFont" key="IBUIFont">
-							<string key="NSName">Helvetica-Bold</string>
-							<double key="NSSize">15</double>
-							<int key="NSfFlags">16</int>
-						</object>
-					</object>
-				</array>
-				<string key="NSFrame">{{0, 20}, {320, 548}}</string>
-				<reference key="NSNextKeyView" ref="706097280"/>
-				<object class="NSColor" key="IBUIBackgroundColor">
-					<int key="NSColorSpace">3</int>
-					<bytes key="NSWhite">MQA</bytes>
-					<object class="NSColorSpace" key="NSCustomColorSpace">
-						<int key="NSID">2</int>
-					</object>
-				</object>
-				<object class="IBUISimulatedStatusBarMetrics" key="IBUISimulatedStatusBarMetrics"/>
-				<object class="IBUIScreenMetrics" key="IBUISimulatedDestinationMetrics">
-					<string key="IBUISimulatedSizeMetricsClass">IBUIScreenMetrics</string>
-					<object class="NSMutableDictionary" key="IBUINormalizedOrientationToSizeMap">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<array key="dict.sortedKeys">
-							<integer value="1"/>
-							<integer value="3"/>
-						</array>
-						<array key="dict.values">
-							<string>{320, 568}</string>
-							<string>{568, 320}</string>
-						</array>
-					</object>
-					<string key="IBUITargetRuntime">IBCocoaTouchFramework</string>
-					<string key="IBUIDisplayName">Retina 4 Full Screen</string>
-					<int key="IBUIType">2</int>
-				</object>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-		</array>
-		<object class="IBObjectContainer" key="IBDocument.Objects">
-			<array class="NSMutableArray" key="connectionRecords">
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchOutletConnection" key="connection">
-						<string key="label">view</string>
-						<reference key="source" ref="372490531"/>
-						<reference key="destination" ref="191373211"/>
-					</object>
-					<int key="connectionID">3</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchEventConnection" key="connection">
-						<string key="label">goForwardButtonPressed</string>
-						<reference key="source" ref="545115536"/>
-						<reference key="destination" ref="372490531"/>
-						<int key="IBEventType">7</int>
-					</object>
-					<int key="connectionID">8</int>
-				</object>
-			</array>
-			<object class="IBMutableOrderedSet" key="objectRecords">
-				<array key="orderedObjects">
-					<object class="IBObjectRecord">
-						<int key="objectID">0</int>
-						<array key="object" id="0"/>
-						<reference key="children" ref="1000"/>
-						<nil key="parent"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1</int>
-						<reference key="object" ref="191373211"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="706097280"/>
-							<reference ref="545115536"/>
-						</array>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-1</int>
-						<reference key="object" ref="372490531"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">File's Owner</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-2</int>
-						<reference key="object" ref="975951072"/>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">4</int>
-						<reference key="object" ref="706097280"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">7</int>
-						<reference key="object" ref="545115536"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-				</array>
-			</object>
-			<dictionary class="NSMutableDictionary" key="flattenedProperties">
-				<string key="-1.CustomClassName">FirstViewController</string>
-				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="-2.CustomClassName">UIResponder</string>
-				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="4.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="7.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			</dictionary>
-			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
-			<nil key="activeLocalization"/>
-			<dictionary class="NSMutableDictionary" key="localizations"/>
-			<nil key="sourceID"/>
-			<int key="maxID">8</int>
-		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes"/>
-		<int key="IBDocument.localizationMode">0</int>
-		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
-		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<string key="IBCocoaTouchPluginVersion">2083</string>
-	</data>
-</archive>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="5056" systemVersion="13D65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
+    <dependencies>
+        <deployment defaultVersion="1552" identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="FirstViewController">
+            <connections>
+                <outlet property="view" destination="1" id="3"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="1">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Home View Controller" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="4">
+                    <rect key="frame" x="77" y="115" width="166" height="21"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="7">
+                    <rect key="frame" x="102" y="180" width="109" height="44"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <state key="normal" title="Go Forward">
+                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                    </state>
+                    <connections>
+                        <action selector="goForwardButtonPressed" destination="-1" eventType="touchUpInside" id="8"/>
+                    </connections>
+                </button>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+            <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
+            <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
+        </view>
+    </objects>
+</document>

--- a/ChangingBackground/PushAnimator.h
+++ b/ChangingBackground/PushAnimator.h
@@ -1,0 +1,15 @@
+//
+//  PushAnimator.h
+//  ChangingBackground
+//
+//  Created by Brock Boland on 6/29/14.
+//  Copyright (c) 2014 Ora Interactive. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface PushAnimator : NSObject <UIViewControllerAnimatedTransitioning>
+
+@property (nonatomic) BOOL reverse;
+
+@end

--- a/ChangingBackground/PushAnimator.m
+++ b/ChangingBackground/PushAnimator.m
@@ -1,0 +1,53 @@
+//
+//  PushAnimator.m
+//  ChangingBackground
+//
+//  Created by Brock Boland on 6/29/14.
+//  Copyright (c) 2014 Ora Interactive. All rights reserved.
+//
+
+#import "PushAnimator.h"
+
+@implementation PushAnimator
+
+-(NSTimeInterval)transitionDuration:(id<UIViewControllerContextTransitioning>)transitionContext {
+  return 0.5;
+}
+
+-(void)animateTransition:(id<UIViewControllerContextTransitioning>)transitionContext {
+  UIViewController* toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
+  UIViewController* fromViewController = [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
+  [[transitionContext containerView] addSubview:toViewController.view];
+
+  CGRect targetFrameForNewController = toViewController.view.frame;
+  CGFloat targetXForOldController = 0;
+
+  if (self.reverse) {
+    // Going backwards: popping a view off
+    // Move the "to" controller offscreen to the left to animate from there
+    toViewController.view.frame = CGRectMake(-toViewController.view.frame.size.width, 0, toViewController.view.frame.size.width, toViewController.view.frame.size.height);
+    // Move the old one to the right
+    targetXForOldController = fromViewController.view.frame.size.width;
+  }
+  else {
+    // Going forwards: pushing a view on
+    // Move the "to" controller offscreen to the right to animate from there
+    toViewController.view.frame = CGRectMake(toViewController.view.frame.size.width, 0, toViewController.view.frame.size.width, toViewController.view.frame.size.height);
+    // Move the old one to the left
+    targetXForOldController = -fromViewController.view.frame.size.width;
+  }
+
+
+  [UIView animateWithDuration:[self transitionDuration:transitionContext] animations:^{
+    // Move the old VC off either left or right
+    fromViewController.view.transform = CGAffineTransformMakeTranslation(targetXForOldController, 0);
+    // Move the new VC to the middle
+    toViewController.view.frame = targetFrameForNewController;
+  } completion:^(BOOL finished) {
+    fromViewController.view.transform = CGAffineTransformIdentity;
+    [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
+
+  }];
+}
+
+@end

--- a/ChangingBackground/SecondViewController.h
+++ b/ChangingBackground/SecondViewController.h
@@ -7,8 +7,9 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "BackgroundImageViewController.h"
 
-@interface SecondViewController : UIViewController
+@interface SecondViewController : BackgroundImageViewController
 
 - (IBAction)goBackButtonPressed;
 

--- a/ChangingBackground/SecondViewController.m
+++ b/ChangingBackground/SecondViewController.m
@@ -11,12 +11,8 @@
 
 @implementation SecondViewController
 
--(id)init {
-  self = [super init];
-  if (self) {
-    self.backgroundImage = [UIImage imageNamed:@"green"];
-  }
-  return self;
+-(UIImage *)backgroundImage {
+  return [UIImage imageNamed:@"green"];
 }
 
 

--- a/ChangingBackground/SecondViewController.m
+++ b/ChangingBackground/SecondViewController.m
@@ -11,6 +11,16 @@
 
 @implementation SecondViewController
 
+-(id)init {
+  self = [super init];
+  if (self) {
+    self.backgroundImage = [UIImage imageNamed:@"green"];
+  }
+  return self;
+}
+
+
+
 - (IBAction)goBackButtonPressed {
     [self.navigationController popViewControllerAnimated:YES];
 }

--- a/ChangingBackground/SecondViewController.xib
+++ b/ChangingBackground/SecondViewController.xib
@@ -1,243 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="8.00">
-	<data>
-		<int key="IBDocument.SystemTarget">1552</int>
-		<string key="IBDocument.SystemVersion">12C3006</string>
-		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
-		<string key="IBDocument.AppKitVersion">1187.34</string>
-		<string key="IBDocument.HIToolboxVersion">625.00</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">2083</string>
-		</object>
-		<array key="IBDocument.IntegratedClassDependencies">
-			<string>IBProxyObject</string>
-			<string>IBUIButton</string>
-			<string>IBUILabel</string>
-			<string>IBUIView</string>
-		</array>
-		<array key="IBDocument.PluginDependencies">
-			<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-		</array>
-		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
-			<integer value="1" key="NS.object.0"/>
-		</object>
-		<array class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
-			<object class="IBProxyObject" id="372490531">
-				<string key="IBProxiedObjectIdentifier">IBFilesOwner</string>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-			<object class="IBProxyObject" id="975951072">
-				<string key="IBProxiedObjectIdentifier">IBFirstResponder</string>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-			<object class="IBUIView" id="191373211">
-				<reference key="NSNextResponder"/>
-				<int key="NSvFlags">274</int>
-				<array class="NSMutableArray" key="NSSubviews">
-					<object class="IBUILabel" id="608025062">
-						<reference key="NSNextResponder" ref="191373211"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{71, 118}, {209, 21}}</string>
-						<reference key="NSSuperview" ref="191373211"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="296395786"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="IBUIOpaque">NO</bool>
-						<bool key="IBUIClipsSubviews">YES</bool>
-						<int key="IBUIContentMode">7</int>
-						<bool key="IBUIUserInteractionEnabled">NO</bool>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<string key="IBUIText">Second View Controller</string>
-						<object class="NSColor" key="IBUITextColor">
-							<int key="NSColorSpace">1</int>
-							<bytes key="NSRGB">MCAwIDAAA</bytes>
-							<string key="IBUIColorCocoaTouchKeyPath">darkTextColor</string>
-						</object>
-						<nil key="IBUIHighlightedColor"/>
-						<int key="IBUIBaselineAdjustment">0</int>
-						<object class="IBUIFontDescription" key="IBUIFontDescription">
-							<int key="type">1</int>
-							<double key="pointSize">17</double>
-						</object>
-						<object class="NSFont" key="IBUIFont">
-							<string key="NSName">Helvetica</string>
-							<double key="NSSize">17</double>
-							<int key="NSfFlags">16</int>
-						</object>
-						<bool key="IBUIAdjustsFontSizeToFit">NO</bool>
-					</object>
-					<object class="IBUIButton" id="296395786">
-						<reference key="NSNextResponder" ref="191373211"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{118, 178}, {85, 44}}</string>
-						<reference key="NSSuperview" ref="191373211"/>
-						<reference key="NSWindow"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="IBUIOpaque">NO</bool>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<int key="IBUIContentHorizontalAlignment">0</int>
-						<int key="IBUIContentVerticalAlignment">0</int>
-						<int key="IBUIButtonType">1</int>
-						<string key="IBUINormalTitle">Go Back</string>
-						<object class="NSColor" key="IBUIHighlightedTitleColor">
-							<int key="NSColorSpace">3</int>
-							<bytes key="NSWhite">MQA</bytes>
-						</object>
-						<object class="NSColor" key="IBUINormalTitleColor">
-							<int key="NSColorSpace">1</int>
-							<bytes key="NSRGB">MC4xOTYwNzg0MzQ2IDAuMzA5ODAzOTMyOSAwLjUyMTU2ODY1NgA</bytes>
-						</object>
-						<object class="NSColor" key="IBUINormalTitleShadowColor">
-							<int key="NSColorSpace">3</int>
-							<bytes key="NSWhite">MC41AA</bytes>
-						</object>
-						<object class="IBUIFontDescription" key="IBUIFontDescription">
-							<int key="type">2</int>
-							<double key="pointSize">15</double>
-						</object>
-						<object class="NSFont" key="IBUIFont">
-							<string key="NSName">Helvetica-Bold</string>
-							<double key="NSSize">15</double>
-							<int key="NSfFlags">16</int>
-						</object>
-					</object>
-				</array>
-				<string key="NSFrame">{{0, 20}, {320, 548}}</string>
-				<reference key="NSSuperview"/>
-				<reference key="NSWindow"/>
-				<reference key="NSNextKeyView" ref="608025062"/>
-				<object class="NSColor" key="IBUIBackgroundColor">
-					<int key="NSColorSpace">3</int>
-					<bytes key="NSWhite">MQA</bytes>
-					<object class="NSColorSpace" key="NSCustomColorSpace">
-						<int key="NSID">2</int>
-					</object>
-				</object>
-				<object class="IBUISimulatedStatusBarMetrics" key="IBUISimulatedStatusBarMetrics"/>
-				<object class="IBUIScreenMetrics" key="IBUISimulatedDestinationMetrics">
-					<string key="IBUISimulatedSizeMetricsClass">IBUIScreenMetrics</string>
-					<object class="NSMutableDictionary" key="IBUINormalizedOrientationToSizeMap">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<array key="dict.sortedKeys">
-							<integer value="1"/>
-							<integer value="3"/>
-						</array>
-						<array key="dict.values">
-							<string>{320, 568}</string>
-							<string>{568, 320}</string>
-						</array>
-					</object>
-					<string key="IBUITargetRuntime">IBCocoaTouchFramework</string>
-					<string key="IBUIDisplayName">Retina 4 Full Screen</string>
-					<int key="IBUIType">2</int>
-				</object>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-		</array>
-		<object class="IBObjectContainer" key="IBDocument.Objects">
-			<array class="NSMutableArray" key="connectionRecords">
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchOutletConnection" key="connection">
-						<string key="label">view</string>
-						<reference key="source" ref="372490531"/>
-						<reference key="destination" ref="191373211"/>
-					</object>
-					<int key="connectionID">3</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchEventConnection" key="connection">
-						<string key="label">goBackButtonPressed</string>
-						<reference key="source" ref="296395786"/>
-						<reference key="destination" ref="372490531"/>
-						<int key="IBEventType">7</int>
-					</object>
-					<int key="connectionID">10</int>
-				</object>
-			</array>
-			<object class="IBMutableOrderedSet" key="objectRecords">
-				<array key="orderedObjects">
-					<object class="IBObjectRecord">
-						<int key="objectID">0</int>
-						<array key="object" id="0"/>
-						<reference key="children" ref="1000"/>
-						<nil key="parent"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1</int>
-						<reference key="object" ref="191373211"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="608025062"/>
-							<reference ref="296395786"/>
-						</array>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-1</int>
-						<reference key="object" ref="372490531"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">File's Owner</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-2</int>
-						<reference key="object" ref="975951072"/>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">4</int>
-						<reference key="object" ref="296395786"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">7</int>
-						<reference key="object" ref="608025062"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-				</array>
-			</object>
-			<dictionary class="NSMutableDictionary" key="flattenedProperties">
-				<string key="-1.CustomClassName">SecondViewController</string>
-				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="-2.CustomClassName">UIResponder</string>
-				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="4.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="7.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			</dictionary>
-			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
-			<nil key="activeLocalization"/>
-			<dictionary class="NSMutableDictionary" key="localizations"/>
-			<nil key="sourceID"/>
-			<int key="maxID">10</int>
-		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes">
-			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<object class="IBPartialClassDescription">
-					<string key="className">SecondViewController</string>
-					<string key="superclassName">UIViewController</string>
-					<object class="NSMutableDictionary" key="actions">
-						<string key="NS.key.0">goBackButtonPressed</string>
-						<string key="NS.object.0">id</string>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<string key="NS.key.0">goBackButtonPressed</string>
-						<object class="IBActionInfo" key="NS.object.0">
-							<string key="name">goBackButtonPressed</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/SecondViewController.h</string>
-					</object>
-				</object>
-			</array>
-		</object>
-		<int key="IBDocument.localizationMode">0</int>
-		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
-		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<string key="IBCocoaTouchPluginVersion">2083</string>
-	</data>
-</archive>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="5056" systemVersion="13D65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
+    <dependencies>
+        <deployment defaultVersion="1552" identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SecondViewController">
+            <connections>
+                <outlet property="view" destination="1" id="3"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="1">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Second View Controller" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="7">
+                    <rect key="frame" x="71" y="118" width="209" height="21"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="4">
+                    <rect key="frame" x="118" y="178" width="60" height="30"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <state key="normal" title="Go Back">
+                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                    </state>
+                    <connections>
+                        <action selector="goBackButtonPressed" destination="-1" eventType="touchUpInside" id="10"/>
+                    </connections>
+                </button>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+            <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
+            <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
+        </view>
+    </objects>
+</document>


### PR DESCRIPTION
In order to implement this, I made a couple of changes to the starting code provided:
- Created a parent class for the two view controllers, to define a `backgroundImage` method
- Created a navigation controller subclass, to display the UIImageView behind its contents

The BackgroundNavigationViewController makes use of a custom transition, to get around the shadowy right border shown on the view controller that comes in during the default push transition (which looks funky scrolling over the background image).

I declined to add a three-letter prefix on the file names, to follow the standard set by the provided code, but normally do so in accordance with Apple's recommendations.

I'll be emailing Jeffrey shortly.
